### PR TITLE
fix(deps): force elliptic >=6.6.1 to resolve Dependabot alert #47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3607,10 +3607,11 @@
       }
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -11127,7 +11128,7 @@
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "bn.js": "^5.2.1",
-        "elliptic": "6.5.4",
+        "elliptic": "^6.6.1",
         "hash.js": "1.1.7"
       }
     },
@@ -11254,7 +11255,7 @@
             "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.6.1",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
             "rlp": "^2.2.3"
@@ -13480,9 +13481,9 @@
       }
     },
     "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
@@ -14290,7 +14291,7 @@
           "requires": {
             "aes-js": "3.0.0",
             "bn.js": "^4.11.9",
-            "elliptic": "6.5.4",
+            "elliptic": "^6.6.1",
             "hash.js": "1.1.3",
             "js-sha3": "0.5.7",
             "scrypt-js": "2.0.4",
@@ -14692,7 +14693,7 @@
             "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.6.1",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
             "rlp": "^2.2.3"
@@ -17198,7 +17199,7 @@
       "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
       "dev": true,
       "requires": {
-        "elliptic": "^6.5.4",
+        "elliptic": "^6.6.1",
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "prettier": "^3.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0"
+  },
+  "overrides": {
+    "elliptic": "^6.6.1"
   }
 }


### PR DESCRIPTION
Resolves Dependabot security alert #47.

- GHSA: GHSA-vjh7-7g9h-fjfh
- Severity: critical (CVSS 4.0 = 9.0)
- Title: Elliptic's private key extraction in ECDSA upon signing a malformed input (e.g. a string)
- CWE: CWE-200 — Exposure of Sensitive Information to an Unauthorized Actor
- Vulnerable: `<= 6.6.0`
- Patched: `6.6.1`

### How `elliptic` enters the tree

The dependency is declared as **transitive, development** scope. It is brought in by every Hardhat-side path that performs ECDSA:

- `hardhat` -> `@metamask/eth-sig-util` -> `ethereumjs-util` -> `elliptic`
- `hardhat` -> `@ethersproject/signing-key` -> `elliptic`
- `hardhat` -> `ethereum-cryptography` -> `secp256k1` -> `elliptic`
- `hardhat` -> `ethereumjs-abi` -> `ethereumjs-util` -> `elliptic`
- `@nomicfoundation/hardhat-toolbox` -> `hardhat-gas-reporter` -> `eth-gas-reporter` -> `ethers@4` -> `elliptic`

Before the fix the resolved version was `elliptic@6.5.4`. None of those parents currently publish a `>=6.6.1` release on their own, so a direct bump is not possible.

### Remediation

Add an npm `overrides` entry forcing `elliptic` to `^6.6.1`. All parents' existing semver ranges (`^6.5.2`, `^6.5.4`) accept 6.6.x, and the override marks `ethereumjs-util`'s resolved version as `overridden` — the others dedupe to 6.6.1.

```jsonc
// package.json
"overrides": {
  "elliptic": "^6.6.1"
}
```

### Verification

- `npm ls elliptic --all` -> every entry now `elliptic@6.6.1` (3x deduped, 1x overridden, root)
- `node_modules/elliptic/package.json` reports `6.6.1`
- `npm audit` no longer reports the `vjh7` advisory (the surviving `elliptic` line is a different, lower-impact advisory GHSA-848j, left for a separate fix)
- `npm install` succeeds cleanly with no peer-dep failures; lockfile delta is +15/-11
- `npx hardhat --version` loads the full Hardhat + toolbox toolchain (`2.22.6`) without error, exercising every `elliptic` consumer path
- `npx hardhat compile` reaches the Solidity stage (the failure observed there — `MockERC20Upgradeable.sol` requires Solidity `^0.8.20` which is not in `hardhat.config.ts`'s compiler list — is **pre-existing on `origin/main`** and unrelated to this change; verified by reproducing with the diff stashed)

### Follow-up

Drop the `overrides` block once any of the parents above ships with `elliptic >= 6.6.1` on its own.

Refs: alert #47, https://github.com/indutny/elliptic/security/advisories/GHSA-vjh7-7g9h-fjfh