### PR TITLE
fix(deps): force adm-zip >=0.6.0 to resolve GHSA-xcpc-8h2w-3j85

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2425,13 +2425,13 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
-      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=0.3.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/aes-js": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "typescript": "^5.0.0"
   },
   "overrides": {
+    "adm-zip": "^0.6.0",
     "elliptic": "^6.6.1",
     "pbkdf2": "^3.1.3"
   }


### PR DESCRIPTION
Resolves Dependabot alert #167: https://github.com/marc-aurele-besner/wallets-tracker/security/dependabot/167

## Vulnerability
- **Package:** `adm-zip` (transitive dev dependency via `hardhat@2.29.0`)
- **Advisory:** GHSA-xcpc-8h2w-3j85
- **CVE:** CVE-2026-39244 (severity: high, CVSS 7.5)
- **Issue:** A crafted ZIP file with a manipulated uncompressed size header field can trigger a ~4GB memory allocation, causing a denial of service. The allocation occurs before CRC validation.

## Remediation
`adm-zip` is pinned to `^0.4.16` by `hardhat@2.29.0`. The patched version (`0.6.0`) cannot be reached by bumping `hardhat` without a major version migration to `hardhat` 3.x, which is out of scope for a security fix.

This PR adds an `overrides` entry in `package.json` to force `adm-zip@^0.6.0`, following the same pattern already used for `elliptic` and `pbkdf2`. Verified by reinstalling and running a smoke test against the public API (`addFile`, `toBuffer`, `readAsText`).

## Follow-up
Remove the `adm-zip` override once the project migrates to `hardhat` 3.x, which declares `adm-zip: ^0.6.0` directly.