### PR TITLE
fix(deps): force serialize-javascript >=7.0.3 to resolve GHSA-5c6j-r48x-rmvq

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8588,6 +8588,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -9286,13 +9287,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "adm-zip": "^0.6.0",
     "elliptic": "^6.6.1",
     "pbkdf2": "^3.1.3",
+    "serialize-javascript": "^7.0.3",
     "tmp": "^0.2.6"
   }
 }


### PR DESCRIPTION
## Summary

Fixes Dependabot alert #94 ([link](https://github.com/marc-aurele-besner/wallets-tracker/security/dependabot/94)) — **high severity** (CVSS 8.1) RCE in `serialize-javascript <= 7.0.2` via unsanitized `RegExp.flags` and `Date.prototype.toISOString()` interpolation.

## Dependency path

`serialize-javascript@6.0.2` entered the tree transitively through:

- `hardhat` → `mocha@11.8.0` (declared `^6.0.2`)
- `@nomicfoundation/hardhat-toolbox` → `hardhat-gas-reporter` → `eth-gas-reporter` → `mocha@10.8.2` (declared `^6.0.2`)
- `@nomicfoundation/hardhat-toolbox` → `solidity-coverage` → `mocha@10.8.2` (declared `^6.0.2`)

Both mocha versions pin `^6.0.2` in their own manifests, so a direct bump on the parent wasn't an option without breaking the range.

## Remediation

Added an `overrides` entry to force `serialize-javascript` to `^7.0.3` (first patched version). Lockfile now resolves to `7.1.0`.

```json
"overrides": {
  ...
  "serialize-javascript": "^7.0.3",
  ...
}
```

Verified:
- `npm ls serialize-javascript --all` → 7.1.0 at every parent path
- `npm audit` no longer flags GHSA-5c6j-r48x-rmvq
- `require('serialize-javascript')` and `require('mocha')` both load cleanly
- `npx hardhat --version` still works

## Follow-up

**Node 20 requirement:** `serialize-javascript@7.x` declares `engines.node: >=20.0.0`. The `.github/workflows/tracking.yml` workflow currently uses `node-version: 16` but is fully commented out (no schedule, pull_request, or workflow_dispatch triggers), so this is not blocking today. If the workflow is re-enabled, bump `actions/setup-node` to `node-version: 20` in the same change.

**Remove the override once feasible:** Drop the `serialize-javascript` entry from `overrides` once both `mocha@10.x` and `mocha@11.x` accept `serialize-javascript@>=7` in their declared ranges.

## Out of scope

Pre-existing `tsc --noEmit` errors in `scripts/trackWalletsAndGenerateReport.ts` (ethers v5 `BigNumber` API used under ethers v6 types) are unrelated to this fix and were not touched.