### PR TITLE
fix(deps): force lodash >=4.18.0 to resolve GHSA-r5fr-rjxr-66jc (CVE-2026-4800)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7531,9 +7531,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "overrides": {
     "adm-zip": "^0.6.0",
     "elliptic": "^6.6.1",
+    "lodash": "^4.18.0",
     "pbkdf2": "^3.1.3",
     "serialize-javascript": "^7.0.3",
     "tmp": "^0.2.6"


### PR DESCRIPTION
Resolves [Dependabot alert #115](https://github.com/marc-aurele-besner/wallets-tracker/security/dependabot/115).

## Vulnerability

| | |
|---|---|
| **Package** | `lodash` (npm, transitive, dev scope) |
| **Advisory** | [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) / CVE-2026-4800 |
| **Severity** | High (CVSS 3.1: 8.1) |
| **CWE** | CWE-94 — Improper Control of Generation of Code (Code Injection) |
| **Vulnerable range** | `>= 4.0.0, <= 4.17.23` (was on `4.17.21`) |
| **First patched** | `4.18.0` (installed `4.18.1`) |

The fix for CVE-2021-23337 validated the `variable` option of `_.template` but left `options.imports` key names unvalidated, and both flow into the same `Function()` sink. `_.template` also merged imports with `assignInWith`, enumerating inherited properties, so a polluted `Object.prototype` would be copied into the imports object and passed to `Function()`.

## How it entered the tree

A single deduped `lodash@4.17.21` reached by 7 paths, all under the hardhat toolchain:

```
├─┬ @nomicfoundation/hardhat-toolbox@5.0.0
│ ├─┬ @nomicfoundation/hardhat-ignition-ethers → @nomicfoundation/ignition-core  (pins lodash 4.17.21)
│ ├─┬ @typechain/ethers-v6@0.5.1
│ ├─┬ hardhat-gas-reporter → eth-gas-reporter@0.2.27
│ ├─┬ solidity-coverage@0.8.17  (+ node-emoji@1.11.0)
│ └─┬ typechain@8.3.2
└─┬ hardhat@2.29.0
```

## Remediation

Added `"lodash": "^4.18.0"` to the existing `overrides` block, matching the convention already used in this repo for `adm-zip`, `elliptic`, `pbkdf2`, `serialize-javascript`, and `tmp`.

**Why an override rather than a parent bump:** `@nomicfoundation/ignition-core@0.15.15` hard-pins `"lodash": "4.17.21"` as an exact version, so no parent release currently pulls a patched lodash. An override is the only way to clear all 7 paths.

**Why this is safe:** `lodash@4.18.1` has no dependencies and no engine constraints. 4.18.0 is a security release with no API removals; its only behavior changes are narrow and security-driven (`_.unset`/`_.omit` now refuse `constructor`/`prototype` path traversal, and `_.template` throws on invalid `imports` keys). 4.18.1 additionally fixes a `ReferenceError` in the modular `template`/`fromPairs` builds. `lodash` is not imported anywhere in this repository’s own source — it is purely tooling-internal.

## Verification

- `rm -rf node_modules && npm install` — clean install, no peer or resolution warnings
- `npm ls lodash --all` — all 7 paths now resolve to `4.18.1`; no `4.17.x` copy remains in `package-lock.json`
- `npm audit` — no lodash advisories remain
- `lodash.template` is not present in the tree
- `npx hardhat compile` — hardhat boots and runs its full pipeline (loading ignition-core, typechain, gas-reporter and solidity-coverage, i.e. every lodash consumer) identically to before
- `npx tsc --noEmit` — **85 errors before, 85 after**: zero regression

Pre-existing issues on `main`, unrelated to this change and deliberately left alone: the 85 `tsc` errors are ethers v5→v6 API drift (`ethers.BigNumber`, `ethers.utils`), `hardhat compile` fails `HH606` because the configured solc `0.8.16` predates the OpenZeppelin contracts’ `^0.8.20` pragma, and `.eslintrc.js` is invalid for ESLint 8 (`parser` set to an array). Each was reproduced against `main`’s dependency tree to confirm it is not caused by this bump.

> **Note on CI:** every trigger in `.github/workflows/tracking.yml` is commented out, so no checks will run on this PR. Verification above was performed locally.

## Follow-up

Remove the `lodash` override once `@nomicfoundation/ignition-core` and the other hardhat-toolbox packages ship `lodash >=4.18.0` themselves.