### PR TITLE
fix(deps): force undici >=6.28.0 to resolve GHSA-m8rv-5g2x-5cg5 (CVE-2026-15157)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -955,16 +955,6 @@
         "@ethersproject/strings": "^5.8.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -11124,16 +11114,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "pbkdf2": "^3.1.3",
     "serialize-javascript": "^7.0.3",
     "tmp": "^0.2.6",
+    "undici": "^6.28.0",
     "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
Fixes Dependabot alert #185.

## Vulnerability

- **Advisory:** GHSA-m8rv-5g2x-5cg5 / CVE-2026-15157
- **Severity:** Medium (CVSS 4.2)
- **Summary:** undici < 6.28.0 is vulnerable to CRLF injection via the blob-like body `type` property in its HTTP/1.1 dispatcher. An attacker controlling the `type` of a duck-typed blob can inject CRLF sequences to append arbitrary HTTP headers and potentially smuggle a second request past the upstream.

## Dependency path

`undici@5.29.0` is pulled in transitively by:

- `hardhat@2.29.0` (declares `undici: ^5.14.0`)
- `@nomicfoundation/hardhat-verify@2.1.3` (declared by `@nomicfoundation/hardhat-toolbox@5.0.0`, also declares `undici: ^5.14.0`)

The undici 5.x line has no patched release — the first patched version is 6.28.0. Both parents cap their range at `^5.14.0`, so the only installable remediation is an `overrides` entry.

## Remediation

Add `undici: ^6.28.0` to `overrides` in `package.json` (matching the existing pattern used for `ws`, `lodash`, `serialize-javascript`, etc.), then regenerate the lockfile. This lands undici 6.28.0 in the tree and resolves the alert.

## Verification

- `npm ls undici --all` → `6.28.0` (deduped, both parents now point to the overridden version).
- `npm audit` → no longer reports the undici advisory (38 unrelated advisories remain; out of scope).
- `npx hardhat run scripts/trackWalletsAndGenerateReport.ts` loads and executes past module resolution; the only error is the script reading undefined env vars (expected without CI secrets).
- The pre-existing `tsc` errors in `scripts/shared/*` and `scripts/trackWalletsAndGenerateReport.ts` are unrelated to this change (present on `main` before the override).

## Follow-up

The override can be removed once hardhat ships a release that accepts `undici >= 6.x` (likely a future hardhat 2.x patch release that bumps `@nomicfoundation/hardhat-verify` or a migration to hardhat 3.x).