### PR TITLE
fix(deps): force cookie >=0.7.0 to resolve GHSA-pxg6-pf52-xh8x (CVE-2024-47764)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3645,9 +3645,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "overrides": {
     "adm-zip": "^0.6.0",
+    "cookie": "^0.7.0",
     "elliptic": "^6.6.1",
     "lodash": "^4.18.0",
     "pbkdf2": "^3.1.3",


### PR DESCRIPTION
## Summary

Resolves Dependabot alert #39 ([GHSA-pxg6-pf52-xh8x](https://github.com/marc-aurele-besner/wallets-tracker/security/dependabot/39), CVE-2024-47764) by forcing `cookie >=0.7.0` via the npm `overrides` block.

## Vulnerability

`cookie < 0.7.0` accepts cookie name, path, and domain with out-of-bounds characters, allowing the cookie name to set other fields (e.g. XSS via crafted input to `serialize`). Upgrading to 0.7.0+ validates these fields.

## Path

The package is transitive (dev-only) via:
```
wallets-tracker → hardhat@2.29.0 → @sentry/node@5.30.0 → cookie@0.4.2
```

## Remediation

Added `"cookie": "^0.7.0"` to the existing `overrides` block in `package.json`. After `npm install`, `cookie` now resolves to 0.7.2, the lockfile is regenerated, and the alert no longer appears in `npm audit`.

Matches the pattern used by the previous dependabot fixes in this repo (uuid, undici, ws, lodash, serialize-javascript, tmp, adm-zip, pbkdf2).

## Verification

- `npm ls cookie --all` → `cookie@0.7.2 overridden`
- `npm audit` → `cookie` no longer listed
- `npx hardhat --version` → still loads correctly (2.29.0)

## Follow-up

This is a temporary override. Once `hardhat` ships a version that pulls in @sentry/node with a patched cookie, the override can be removed.

## Alerts

- https://github.com/marc-aurele-besner/wallets-tracker/security/dependabot/39